### PR TITLE
feat: update `CYPRESS_CACHE_FOLDER` value

### DIFF
--- a/actions/setup/node/action.yml
+++ b/actions/setup/node/action.yml
@@ -58,7 +58,7 @@ runs:
         npm -v
 
     - shell: bash
-      run: echo "CYPRESS_CACHE_FOLDER=./node_modules/cache-cypress" >> $GITHUB_ENV
+      run: echo "CYPRESS_CACHE_FOLDER=./node_modules/cypress/cache-cypress" >> $GITHUB_ENV
 
     - name: Restore node_modules from cache
       id: cache-node-modules


### PR DESCRIPTION
### Previous behavior
```
→ tree ./node_modules/cache-cypress -L 1
./node_modules/cache-cypress
└── 13.15.0

→ npm install any-new-package

→ tree ./node_modules/cache-cypress -L 1
./node_modules/cache-cypress  [error opening dir]

0 directories, 0 files
```

### New behavior
```
→ tree ./node_modules/cypress/cache-cypress -L 1
./node_modules/cypress/cache-cypress
└── 13.15.0

→ npm install any-new-package

→ tree ./node_modules/cypress/cache-cypress -L 1
./node_modules/cypress/cache-cypress
└── 13.15.0
```

