### PR TITLE
fix: ensure that root package-lock.json will be included

### DIFF
--- a/actions/setup/node/action.yml
+++ b/actions/setup/node/action.yml
@@ -65,7 +65,7 @@ runs:
       uses: actions/cache@v4.2.4
       with:
         path: ${{ inputs.node-path }}
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}-${{ hashFiles('**/package-lock.json') }}
 
     - name: Load Nx cache state for NX_BASE
       uses: actions/cache@v4


### PR DESCRIPTION
Problem:

After some merging to the main branch, the current pull request reused the cache from the main, although my pull request contains an old lock file with critical vulnerabilities, but local node modules were not created.

<img width="1142" height="478" alt="image" src="https://github.com/user-attachments/assets/a8dc2311-59ff-441a-90cb-daf90bc768d0" />
